### PR TITLE
Add option to choose a different StackExchange site to generate the card

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If you want to have a compact layout, just you need to add `layout=compact` as a
 | userID     | Your StackOverflow userID            | REQUIRED                |
 | theme      | Theme of the StackOverflow card (light or dark)      | light     |
 | layout     | Layout of the StackOverflow card (compact or default) | default |    
+| site | [StackExchange network's](https://stackexchange.com/sites#questionsperday) site to generate your card | stackoverflow |
 
 <br>
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const StackOverflowCard = require('./src/StackOverflowCard');
 
 http.createServer(async (req, res) => {
   const reqURL = url.parse(req.url, true);
-  const { userID, theme = 'light', layout = 'default' } = reqURL.query;
+  const { userID, theme = 'light', layout = 'default', site = 'stackoverflow' } = reqURL.query;
 
   if (!userID) {
     res.write(JSON.stringify({error: 'Add your StackOverflow userID as query string'}));
@@ -13,7 +13,7 @@ http.createServer(async (req, res) => {
     return;
   }
 
-  const responseArticles = await fetch(`https://api.stackexchange.com/2.2/users/${userID}?site=stackoverflow&filter=!--1nZv)deGu1`);
+  const responseArticles = await fetch(`https://api.stackexchange.com/2.2/users/${userID}?site=${site}&filter=!--1nZv)deGu1`);
   const json = await responseArticles.json();
 
   if (!json.items || json.items.length === 0) {
@@ -32,5 +32,5 @@ http.createServer(async (req, res) => {
   res.write(result);
   res.end();
 }).listen(process.env.PORT || 3000, function(){
- console.log("server start at port 3000");
+  console.log("server start at port 3000");
 });


### PR DESCRIPTION
This PR contains a simple modification to allow the user to send a new parameter (called `site`) that can be used to choose a different StackExchange site to generate the card.